### PR TITLE
Change config path of bird-router to (pwd)

### DIFF
--- a/bgp-cp/README.md
+++ b/bgp-cp/README.md
@@ -214,7 +214,7 @@ Run the Bird container:
 ```sh
 docker run --name bird-router \
   --network kind \
---mount type=bind,source=$GOPATH/src/github.com/danehans/cilium-demos/bgp-cp,target=/config \
+--mount type=bind,source=$(pwd),target=/config \
 --cap-add=NET_ADMIN \
 -d bird-container
 ```


### PR DESCRIPTION
When trying to start the bird-router container, the specified path in the command block doesn't work. Suggestion to change the source field to $(pwd) as the user will already be in the /cilium-demos/bgp-cp directory.